### PR TITLE
Fix PDF.co upload, cleanup, and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and fill in your PDF.co API key
+PDF_CO_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+sample.png
+package-lock.json
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # PDF to JSON Dashboard
 
-This project lets you upload Indian FI PDF statements (Deposit, Mutual Fund, Equities) and returns a JSON in AA schema.
+This project lets you upload Indian FI statements (Deposit, Mutual Fund, Equities) as PDF files or screenshots and returns a JSON in AA schema.
 
 ## Quick Start
 
 1. Clone the repo, `npm install`
-2. Run locally: `npm run dev`
-3. Deploy on Vercel: Just push, no config needed!
+2. Copy `.env.example` to `.env` and add your `PDF_CO_API_KEY`
+3. Run locally: `npm run dev`
+4. Deploy on Vercel: Just push, no config needed!
 
-> **Note:**  
-> The PDF.co API key is hardcoded in `/pages/api/parse.js`.  
-> For security, switch to environment variables if open-sourcing.
+Requires Node.js 18+.  Mapping rules live under `/mappers` and can be adjusted for your statement formats.
 
 ## Structure
 
-- `/mappers`: Modular mapping logic for each FI type
+- `/mappers`: Modular mapping logic for each FI type (customize here for your PDFs)
 - `/pages/api/parse.js`: Backend API
 - `/pages/index.js`: Upload UI
 
@@ -26,4 +25,4 @@ This project lets you upload Indian FI PDF statements (Deposit, Mutual Fund, Equ
 
 ## Contribute
 
-Feel free to fork and adapt for new FI types or mapping rules!
+Feel free to fork and adapt for new FI types or mapping rules!  See [LICENSE](LICENSE) for terms.

--- a/pages/api/parse.js
+++ b/pages/api/parse.js
@@ -6,13 +6,16 @@ import { promises as fs } from 'fs';
 
 export const config = { api: { bodyParser: false } };
 
-const PDF_API_KEY = "rupam@onemoney.in_QnyHofU5rttFSoCCV7fJZGshsXCIBAH1lRBtl92hfdEVVqVtMRrZyLT8MDQ6RzUI";
+const PDF_API_KEY = process.env.PDF_CO_API_KEY;
 
 export default async function handler(req, res) {
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
 
   let fileBuffer = null;
+  let mimeType = 'application/pdf';
+  let text;
+  let tempPath = null;
 
   try {
     const form = formidable({ multiples: false, keepExtensions: true });
@@ -25,29 +28,48 @@ export default async function handler(req, res) {
 
     // On Vercel, always an array:
     if (!files.pdf || !Array.isArray(files.pdf) || !files.pdf[0] || !files.pdf[0].filepath) {
-      return res.status(400).json({ error: "No PDF uploaded or path missing" });
+      return res.status(400).json({ error: "No file uploaded or path missing" });
     }
-    fileBuffer = await fs.readFile(files.pdf[0].filepath);
+    tempPath = files.pdf[0].filepath;
+    fileBuffer = await fs.readFile(tempPath);
+    mimeType = files.pdf[0].mimetype || mimeType;
   } catch (e) {
     console.error('Formidable/FS error:', e);
     return res.status(400).json({ error: "File upload failed" });
   }
-
-  let text;
   try {
+    // upload file to PDF.co first
+    const uploadRes = await fetch("https://api.pdf.co/v1/file/upload", {
+      method: "POST",
+      headers: { "x-api-key": PDF_API_KEY },
+      body: fileBuffer,
+    });
+    const uploadData = await uploadRes.json();
+    if (!uploadData || !uploadData.url) {
+      return res.status(500).json({ error: "PDF file upload to PDF.co failed: " + (uploadData.message || 'No URL returned') });
+    }
+    const pdfUrl = uploadData.url;
+
     const pdfResponse = await fetch("https://api.pdf.co/v1/pdf/convert/to/text", {
       method: "POST",
-      headers: { "x-api-key": PDF_API_KEY, "Content-Type": "application/pdf" },
-      body: fileBuffer,
+      headers: {
+        "x-api-key": PDF_API_KEY,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ url: pdfUrl }),
     });
     const data = await pdfResponse.json();
     if (!data || data.error || !data.body) {
-      return res.status(500).json({ error: "PDF parse failed: " + (data && data.message ? data.message : "Unknown error") });
+      return res.status(500).json({ error: "File parse failed: " + (data && data.message ? data.message : "Unknown error") });
     }
     text = data.body;
   } catch (err) {
     console.error('PDF.co fetch error:', err);
     return res.status(500).json({ error: "API request failed: " + err.message });
+  } finally {
+    if (tempPath) {
+      try { await fs.unlink(tempPath); } catch (_) {}
+    }
   }
 
   let fiType = "DEPOSIT";

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,7 @@ export default function Home() {
       if (!res.ok) throw new Error(result.error || 'Unknown error');
       setJson(result);
     } catch (err) {
-      setError('Failed to parse PDF: ' + err.message);
+      setError('Failed to parse file: ' + err.message);
     }
   };
 
@@ -39,7 +39,11 @@ export default function Home() {
   return (
     <div style={{ margin: "40px auto", maxWidth: 700 }}>
       <h1>PDF to JSON Dashboard</h1>
-      <input type="file" accept="application/pdf" onChange={handleFileChange} />
+      <input
+        type="file"
+        accept="application/pdf,image/*"
+        onChange={handleFileChange}
+      />
       {fileName && <span style={{ marginLeft: 8 }}>Selected: <b>{fileName}</b></span>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {json && (


### PR DESCRIPTION
## Summary
- remove hardcoded API key and use `PDF_CO_API_KEY`
- upload files to PDF.co before converting to text
- delete uploaded temp files after reading
- document the environment variable and add MIT license
- ignore `.env`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683feecf3d90832180f83aab722a2673